### PR TITLE
[#17] Enhancement hide sidebar

### DIFF
--- a/frontend/src/components/Sidebar/ChannelLink.js
+++ b/frontend/src/components/Sidebar/ChannelLink.js
@@ -1,0 +1,23 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { NavLink } from "react-router-dom";
+import "./Sidebar.css";
+
+const ChannelLink = ({ channel }) => (
+  <NavLink
+    to={`/channel/${channel.id}`}
+    className="channelLink"
+    activeClassName="channelLinkSelected"
+  >
+    <span>{channel.name}</span>
+  </NavLink>
+);
+
+ChannelLink.propTypes = {
+  channel: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired
+  }).isRequired
+};
+
+export default ChannelLink;

--- a/frontend/src/components/Sidebar/Sidebar.js
+++ b/frontend/src/components/Sidebar/Sidebar.js
@@ -1,73 +1,66 @@
 import React from "react";
-import { Link, NavLink } from "react-router-dom";
+import { Link, withRouter } from "react-router-dom";
 import PropTypes from "prop-types";
+import ChannelLink from "./ChannelLink";
 import "./Sidebar.css";
 
 const Sidebar = ({
   channels,
-  router,
+  history,
   onLogoutClick,
   username: user,
   direct_messages
-}) => (
-  <div className="sidebar">
-    <div className="header">
-      <Link to="/">NeoChat</Link>
-    </div>
-    <div className="username">{user}</div>
-    <div className="channelsTitle">
-      Channels
-      <Link to="/" className="link">
-        <span className="fa fa-plus" />
-      </Link>
-    </div>
-    {channels.map(channel => (
-      <ChannelLink key={channel.id} channel={channel} />
-    ))}
-    <div className="channelsTitle">
-      Direct Messages
-      <Link to="/direct_messages" className="link">
-        <span className="fa fa-plus" />
-      </Link>
-    </div>
-    {direct_messages.map(channel => (
-      <ChannelLink key={channel.id} channel={channel} />
-    ))}
-    <div style={{ flex: "1" }} />
-    <button
-      onClick={() => onLogoutClick(router)}
-      className={["link", "logoutButton"].join(" ")}
-    >
-      <div className="channelLink">
-        <span className="fa fa-sign-out" />
+}) => {
+  if (!user) return null;
+  const directMessageLinks = direct_messages.map(channel => (
+    <ChannelLink key={channel.id} channel={channel} />
+  ));
+  const channelLinks = channels.map(channel => (
+    <ChannelLink key={channel.id} channel={channel} />
+  ));
+
+  return (
+    <div className="sidebar">
+      <div className="header">
+        <Link to="/">NeoChat</Link>
       </div>
-    </button>
-  </div>
-);
+      <div className="username">{user}</div>
+      <div className="channelsTitle">
+        Channels
+        <Link to="/" className="link">
+          <span className="fa fa-plus" />
+        </Link>
+        {channelLinks}
+      </div>
+      <div className="channelsTitle">
+        Direct Messages
+        <Link to="/direct_messages" className="link">
+          <span className="fa fa-plus" />
+        </Link>
+        {directMessageLinks}
+      </div>
+      <button
+        onClick={() => onLogoutClick(history)}
+        className="btn btn-primary"
+      >
+        Logout
+      </button>
+    </div>
+  );
+};
 
-const ChannelLink = ({ channel }) => (
-  <NavLink
-    to={`/channel/${channel.id}`}
-    className="channelLink"
-    activeClassName="channelLinkSelected"
-  >
-    <span>{channel.name}</span>
-  </NavLink>
-);
-
-ChannelLink.propTypes = {
-  channel: PropTypes.shape({
-    id: PropTypes.number.isRequired,
-    name: PropTypes.string.isRequired
-  }).isRequired
+Sidebar.defaultProps = {
+  username: ""
 };
 
 Sidebar.propTypes = {
-  router: PropTypes.object.isRequired,
+  match: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+  history: PropTypes.object.isRequired,
   onLogoutClick: PropTypes.func.isRequired,
-  username: PropTypes.string.isRequired,
+  username: PropTypes.string,
   channels: PropTypes.array.isRequired,
   direct_messages: PropTypes.array.isRequired
 };
 
-export default Sidebar;
+export default withRouter(Sidebar);

--- a/frontend/src/containers/App/AppContainer.js
+++ b/frontend/src/containers/App/AppContainer.js
@@ -24,8 +24,11 @@ class AppContainer extends Component {
     logout: PropTypes.func.isRequired,
     currentUserChannels: PropTypes.array.isRequired,
     currentUserDirectMessageChannels: PropTypes.array.isRequired,
-    currentUser: PropTypes.shape({ username: PropTypes.string.isRequired })
-      .isRequired
+    currentUser: PropTypes.shape({ username: PropTypes.string })
+  };
+
+  static defaultProps = {
+    currentUser: { username: "" }
   };
 
   componentDidMount() {
@@ -37,7 +40,7 @@ class AppContainer extends Component {
     }
   }
 
-  handleLogout = router => this.props.logout(router);
+  handleLogout = history => this.props.logout({ history });
 
   render() {
     return (


### PR DESCRIPTION
- return `null` instead of `Sidebar` when no user is present
- replace pro icon `fa fa-signout` that won't show with button and text
- fix logout issue due to undefined router by wrapping the `Sideabar` in the react-router`withRouter` HoC
- cleanup the maps in the return
- fix some console warnings

<img width="1159" alt="screen shot 2561-04-01 at 18 40 37" src="https://user-images.githubusercontent.com/953287/38172772-69b6a3cc-35dc-11e8-9527-33c3ee7ea63e.png">

<img width="1161" alt="screen shot 2561-04-01 at 18 41 13" src="https://user-images.githubusercontent.com/953287/38172769-5b51ec74-35dc-11e8-8ad0-3c4a86261b8f.png">

Closes https://github.com/CityOfZion/neochat/issues/17